### PR TITLE
Fix peerDependencies/laravel-mix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "peerDependencies": {
         "browser-sync": "^2.26.7",
         "browser-sync-webpack-plugin": "^2.2.2",
-        "laravel-mix": "^4.0|^5.0"
+        "laravel-mix": "^5.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "peerDependencies": {
         "browser-sync": "^2.26.7",
         "browser-sync-webpack-plugin": "^2.2.2",
-        "laravel-mix": "^5.0"
+        "laravel-mix": "^4.0||^5.0"
     }
 }


### PR DESCRIPTION
Line 29 produces a warning while the right version of laravel-mix is installed and stops the execution of _npm install_:
```
$ npm install --save-dev laravel-mix
npm WARN laravel-mix-jigsaw@1.1.0 requires a peer of laravel-mix@^4.0|^5.0 but none is installed. You must install peer dependencies yourself.
```