### PR TITLE
Restore ability to pass proxy URL to BrowserSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class Jigsaw {
 
         this.config = {
             browserSync: true,
+            proxy: undefined,
             watch: [
                 'source/**/*.md',
                 'source/**/*.php',
@@ -39,7 +40,7 @@ class Jigsaw {
     webpackPlugins() {
         return [
             this.jigsawPlugin(),
-            this.config.browserSync ? this.browserSyncPlugin() : null,
+            this.config.browserSync ? this.browserSyncPlugin(this.config.proxy) : null,
             this.config.watch ? this.watchPlugin() : null,
         ];
     }


### PR DESCRIPTION
It was [previously](https://github.com/tightenco/jigsaw/pull/452/files#diff-1145327812397a8084383b910cacca28L9) possible to configure BrowserSync with a custom proxy URL, because the function creating the webpack plugin was called in users' `webpack.mix.js`.

When we extracted that functionality into this package, I mistakenly removed that ability. This PR adds a config option to restore it.