### PR TITLE
Correctly remove unused webpack plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,9 @@ class Jigsaw {
     webpackPlugins() {
         return [
             this.jigsawPlugin(),
-            this.config.browserSync ? this.browserSyncPlugin(this.config.proxy) : null,
-            this.config.watch ? this.watchPlugin() : null,
-        ];
+            this.config.browserSync ? this.browserSyncPlugin(this.config.proxy) : undefined,
+            this.config.watch ? this.watchPlugin() : undefined,
+        ].filter(plugin => plugin);
     }
 
     /**


### PR DESCRIPTION
Passing _anything_ up to webpack that doesn't conform to their plugin API causes an error, and since `null` doesn't have an `apply()` method...

This PR ensures that any unused webpack plugins are removed from the array we pass to webpack, so you can continue do things like `{ browserSync: false }` in your config.

Closes #6.