### PR TITLE
Added custom hook after build has completed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class Jigsaw {
 
         return new class {
             apply(compiler) {
-                compiler.hooks.jigsawWebpackBuildDone = new SyncHook([]);
+                compiler.hooks.jigsawDone = new SyncHook([]);
 
                 compiler.hooks.done.tap('Jigsaw Webpack Plugin', () => {
                     return command.get(`${bin} build -q ${env}`, (error, stdout, stderr) => {
@@ -84,7 +84,7 @@ class Jigsaw {
                             browserSyncInstance.reload();
                         }
 
-                        compiler.hooks.jigsawWebpackBuildDone.call();
+                        compiler.hooks.jigsawDone.call();
                     });
                 });
             }

--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ const BrowserSync = require('browser-sync');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 
-const AsyncSeriesHook = require('tapable').AsyncSeriesHook;
-const SyncHook = require('tapable').SyncHook;
+const { SyncHook } = require('tapable');
 
 let browserSyncInstance;
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class Jigsaw {
                             browserSyncInstance.reload();
                         }
 
-                        compiler.hooks.jigsawWebpackBuildDone.callAsync(() => {});
+                        compiler.hooks.jigsawWebpackBuildDone.call();
                     });
                 });
             }

--- a/index.js
+++ b/index.js
@@ -74,10 +74,6 @@ class Jigsaw {
 
         return new class {
             apply(compiler) {
-                if (compiler.hooks.jigsawWebpackBuildDone) {
-                    throw new Error('Jigsaw webpack build done hooks are already in use.');
-                }
-
                 compiler.hooks.jigsawWebpackBuildDone = new SyncHook([]);
 
                 compiler.hooks.done.tap('Jigsaw Webpack Plugin', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,6 +311,11 @@
                 "ansi-regex": "^5.0.0"
             }
         },
+        "tapable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "extra-watch-webpack-plugin": "^1.0.3",
         "hasbin": "^1.2.3",
         "node-cmd": "^3.0.0",
+        "tapable": "^1.1.3",
         "yargs": "^15.3.1"
     },
     "peerDependencies": {


### PR DESCRIPTION
I am writing a webpack plugin specifically for minifying jigsaw HTML which require access to the outputted HTML after the build process has completed. 

Calling the tapped hooks within the `command.get` callback allows others to run plugin after the build has completed.

For reference please see my plugin (WIP) here: https://github.com/thelevicole/minify-laravel-jigsaw-output-plugin specifically [Line 62](https://github.com/thelevicole/minify-laravel-jigsaw-output-plugin/blob/master/index.js#L62)

