### PR TITLE
Add browserSyncOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class Jigsaw {
                 'source/**/*.scss',
                 '!source/**/cache/*',
             ],
+            browserSyncOptions: {},
             ...config,
         };
     }

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ class Jigsaw {
             port: this.port,
             proxy: proxy,
             server: proxy ? null : { baseDir: 'build_' + this.env + '/' },
-            ...this.config.browserSyncOptions
+            ...this.config.browserSyncOptions,
         }, {
             reload: false,
             callback: () => browserSyncInstance = BrowserSync.get('bs-webpack-plugin'),

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ class Jigsaw {
             port: this.port,
             proxy: proxy,
             server: proxy ? null : { baseDir: 'build_' + this.env + '/' },
+            ...this.config.browserSyncOptions
         }, {
             reload: false,
             callback: () => browserSyncInstance = BrowserSync.get('bs-webpack-plugin'),


### PR DESCRIPTION
This relates to this issue
https://github.com/tightenco/laravel-mix-jigsaw/pull/10
there are many options in browserSync https://www.browsersync.io/docs/options and these are sometimes needed. This simple change allows to add any browsersync option using
```js
.jigsaw({
  browserSyncOptions: {
      anyOption: true
    }
})
```
This also solves also the ```'open'``` and ```'online'``` options (and others) so some of the options are somehow redundant but i am not sure if it wouldn't break @raniesantos build because he uses ```'online'``` and ```'open'```.

The change could have been also simply
```js
...this.config
```
but then everything in ```.jigsaw()``` becomes browserSync option and it might lead to collisions if .jigsaw is used also for something other than browserSync config. I suspect it is so that was the reason why it wasn't like this from the start.