### PR TITLE
Use NODE_ENV to determine Jigsaw environment when possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,15 @@ class Jigsaw {
      * Register the component.
      */
     register(config = {}) {
-        this.env = argv.env || 'local';
+        if (typeof argv.env === 'string') {
+            this.env = argv.env;
+        } else {
+            this.env = process.env.NODE_ENV || 'local';
+            if (this.env === 'development') {
+                this.env = 'local';
+            }
+        }
+
         this.port = argv.port || 3000;
         this.bin = this.binaryPath();
 


### PR DESCRIPTION
Fixes tighten/jigsaw#505 (2/2, see tighten/jigsaw#506). Should be fully backwards-compatible, for anyone with `--env=something` in their build script we'll just keep using that.