### PR TITLE
Allow `npm run watch` to output Jigsaw build errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const bin = existsSync('./vendor/bin/jigsaw') ? normalize('./vendor/bin/jigsaw')
 
 const env = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
-const jigsaw = () => spawn(bin, ['build', '-q', env], {stdio:'inherit'}).on('exit', (code) => {
+const jigsaw = () => spawn(bin, ['build', env], {stdio:'inherit'}).on('exit', (code) => {
     if (code > 0) {
         console.warn(`\nBuild failed. Fix the above and try again.`);
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const mix = require('laravel-mix');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 const { existsSync } = require('fs');
 const { normalize, resolve } = require('path');
 const glob = require('glob');
@@ -13,8 +13,10 @@ const bin = existsSync('./vendor/bin/jigsaw') ? normalize('./vendor/bin/jigsaw')
 
 const env = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
-const jigsaw = () => exec(`${bin} build -q ${env}`, (error, stdout, stderr) => {
-    error ? console.warn(`Error building Jigsaw site:\n${stderr}\n${stdout}`) : console.log(stdout);
+const jigsaw = () => spawn(bin, ['build', '-q', env], {stdio:'inherit'}).on('exit', (code) => {
+    if (code > 0) {
+        console.warn(`\nBuild failed. Fix the above and try again.`);
+    }
 });
 
 // Picks up everything except new files created directly in 'source/'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const bin = existsSync('./vendor/bin/jigsaw') ? normalize('./vendor/bin/jigsaw')
 const env = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
 const jigsaw = () => exec(`${bin} build -q ${env}`, (error, stdout, stderr) => {
-    error ? console.warn(`Error building Jigsaw site:\n${stderr}`) : console.log(stdout);
+    error ? console.warn(`Error building Jigsaw site:\n${stderr}\n${stdout}`) : console.log(stdout);
 });
 
 // Picks up everything except new files created directly in 'source/'


### PR DESCRIPTION
Fix for https://github.com/tighten/laravel-mix-jigsaw/issues/26 by allowing the [lovely error reporting](https://github.com/tighten/jigsaw/pull/668) done for the build command to surface when running `npm run watch`

### Error
<img width="535" alt="Screenshot 2022-12-08 at 23 05 26" src="https://user-images.githubusercontent.com/31628/206585853-8ea3d991-e889-415e-b7ef-9fc18de62d3a.png">

### Success
<img width="350" alt="Screenshot 2022-12-08 at 23 06 01" src="https://user-images.githubusercontent.com/31628/206585859-54272ef7-3eb2-4a4f-b8d2-1ba97d4b40cd.png">
